### PR TITLE
add workflow to build a debug apk for release

### DIFF
--- a/.github/workflows/release_apk.yaml
+++ b/.github/workflows/release_apk.yaml
@@ -1,0 +1,44 @@
+name: Build & Release APK
+on:
+  release:
+    types: [published]
+  # push:
+  #   paths:
+  #     - .github/workflows/release_apk.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: setup jdk
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+          cache: "gradle"
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: test
+        run: tree
+
+      - name: rename apk
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tag="${GITHUB_REF#'refs/tags/'}"
+          cp app/build/outputs/apk/debug/app-debug.apk WeatherApp-$tag-debug.apk
+
+      - name: Upload apk as release asset
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            WeatherApp-*.apk


### PR DESCRIPTION
to build the apk, you need to create a github release and then watch the progress in actions tag. 5 minutes later the built apk will be attached as a release asset

---
part of V4TSAL celebratory month special :partying_face: 